### PR TITLE
Issue #1: automatisk versionering af klient via git tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ with open("README.rst", "r") as fh:
 setup(
     # Keep this name in sync with the one in os2borgerpc_client/jobmanager.py
     name="os2borgerpc_client",
-    version="2.5.0",
+    use_scm_version=True,  # Automatically uses Git tags for versioning
+    setup_requires=['setuptools-scm'],  # Ensure setuptools-scm is used
     description="Client for the OS2borgerPC system",
     long_description=long_description,
     url="https://github.com/OS2borgerPC/",


### PR DESCRIPTION
Automatisk generering af klient version udfra versionering i git (via git tags).

Eksempel ved install fra github via tag:
```bash
pip install git+https://github.com/OS2borgerPC/os2borgerpc-client.git@v2.5.1
```
bliver klienten installeret som version 2.5.1 hvis man laver en 
```bash
pip list / pip show os2borgerpc-client
```

Man kan dermed lave automatisk versionering ift. release management via git tags.