### PR TITLE
RPI kompatibel aflæsning af memeory

### DIFF
--- a/bin/register_new_os2borgerpc_client.sh
+++ b/bin/register_new_os2borgerpc_client.sh
@@ -169,7 +169,7 @@ while true; do
     [ -z "$CPUS" ] && CPUS="Identification failed"
     set_os2borgerpc_config pc_cpus "$CPUS"
 
-    RAM="$(LANG=c lsmem | grep "Total online" | cut --delimiter ':' --fields 2 | xargs)"
+    RAM="$(free -h | awk '/^Mem:/ {print $2}')"
     [ -z "$RAM" ] && RAM="Identification failed"
     RAM=${RAM:0:100}
     set_os2borgerpc_config pc_ram "$RAM"


### PR DESCRIPTION
Kommandoen `lsmem `fungerer ikke på RPI
I stedet aflæses mængden af RAM med kommandoen `free -h` 